### PR TITLE
allow for oversubscribe to be overwritten by nrn CMake

### DIFF
--- a/ci-test.sh
+++ b/ci-test.sh
@@ -16,5 +16,5 @@ else
   $NRNHOME/bin/nrnivmodl -coreneuron -l -lcrypto -loadflags -lcrypto modx
 fi
 
-mpiexec -oversubscribe -n 16 $NRNHOME/bin/nrniv -mpi -python test1.py
+mpiexec ${MPIEXEC_OVERSUBSCRIBE---oversubscribe} -n 16 $NRNHOME/bin/nrniv -mpi -python test1.py
  


### PR DESCRIPTION
From failure in https://github.com/BlueBrain/CoreNeuron/pull/701
```
 mpiexec -oversubscribe -n 16 /gpfs/bbp.cscs.ch/ssd/gitlab_map_jobs/bbpcihpcproj12/P29772/J110989/_/spack-build/spack-stage-neuron-develop-vkogqddlipn6wfzq2o4mkbt36t7uknzy/spack-build-vkogqdd/bin/nrniv -mpi -python test1.py
MPT ERROR: invalid option: -oversubscribe
```
Similar to: https://github.com/neuronsimulator/nrntest/search?q=oversubscribe